### PR TITLE
Link to changes tab

### DIFF
--- a/src/Templates/ModuleInfo.tmpl.php
+++ b/src/Templates/ModuleInfo.tmpl.php
@@ -47,7 +47,7 @@
                                 <div class="alert alert-warning" role="alert">
                                     <strong>Achtung:</strong> Einige Dateien befinden sich nicht mehr im Originalzustand. Möglicherweise hast Du an diesen
                                     Anpassungen vorgenommen. <strong>Deinstallation</strong> und <strong>Update</strong> stehen dir nur bei unveränderten Modulen zur
-                                    Verfügung, damit Deine Arbeit nicht verloren geht. <a href="#" onclick="$('#v-pills-files-tab').tab('show');">Alle Änderungen ansehen</a>.
+                                    Verfügung, damit Deine Arbeit nicht verloren geht. <a href="#v-pills-tabContent" onclick="$('#v-pills-files-tab').tab('show');">Alle Änderungen ansehen</a>.
                                 </div>
                             <?php } ?>
 


### PR DESCRIPTION
- fix: `href="#"` causes page to scroll to top in some browsers and has been changed to link to the tab instead. Clicking the link while the tab is active will cause the browser to jump to the tab.