### PR TITLE
Change view setting installMode as select and modify function invokeSettings() to set installMode

### DIFF
--- a/src/Classes/IndexController.php
+++ b/src/Classes/IndexController.php
@@ -513,6 +513,10 @@ class IndexController
             if (isset($_POST['modulesLocalDir'])) {
                 Config::setModulesLocalDir($_POST['modulesLocalDir']);
             }
+            
+            if (isset($_POST['installMode'])) {
+                Config::setInstallMode($_POST['installMode']);
+            }
 
             Notification::pushFlashMessage([
                 'text' => 'Einstellungen erfolgreich gespeichert.',

--- a/src/Templates/Settings.tmpl.php
+++ b/src/Templates/Settings.tmpl.php
@@ -85,10 +85,10 @@
                                 <!-- installMode -->
                                 <div class="form-group">
                                     <label for="inputInstallMode">Installationsmodus
-									<select name="installMode" class="form-control" id="inputInstallMode" size="1">
-										<option <?php if (Config::getInstallMode() == 'copy') echo 'selected="selected"'; ?> value="copy">copy</option>
-										<option <?php if (Config::getInstallMode() == 'link') echo 'selected="selected"'; ?> value="link">link</option>
-									</select>
+					<select name="installMode" class="form-control" id="inputInstallMode" size="1">
+					    <option <?php if (Config::getInstallMode() == 'copy') echo 'selected="selected"'; ?> value="copy">copy</option>
+					    <option <?php if (Config::getInstallMode() == 'link') echo 'selected="selected"'; ?> value="link">link</option>
+					</select>
                                     </label>
                                     <p>Du kannst zwischen <code>copy</code> und <code>link</code> wählen. Hast du den MMLC in einem Live-Shop im Einsatz, wähle <code>copy</code>. Wenn du mit dem MMLC Module entwickelst, wähle <code>link</code>.</p>
                                 </div>

--- a/src/Templates/Settings.tmpl.php
+++ b/src/Templates/Settings.tmpl.php
@@ -84,8 +84,12 @@
 
                                 <!-- installMode -->
                                 <div class="form-group">
-                                    <label for="inputInstallMode">Installationsmodus</label>
-                                    <input type="text" name="installMode" class="form-control" id="inputInstallMode" value="<?php echo Config::getInstallMode(); ?>">
+                                    <label for="inputInstallMode">Installationsmodus
+									<select name="installMode" class="form-control" id="inputInstallMode" size="1">
+										<option <?php if (Config::getInstallMode() == 'copy') echo 'selected="selected"'; ?> value="copy">copy</option>
+										<option <?php if (Config::getInstallMode() == 'link') echo 'selected="selected"'; ?> value="link">link</option>
+									</select>
+                                    </label>
                                     <p>Du kannst zwischen <code>copy</code> und <code>link</code> wählen. Hast du den MMLC in einem Live-Shop im Einsatz, wähle <code>copy</code>. Wenn du mit dem MMLC Module entwickelst, wähle <code>link</code>.</p>
                                 </div>
 


### PR DESCRIPTION
Change the view of the setting installMode as select. It's more user-friendly. And the invokeSettings () function has been expanded to include installMode. This makes it easier to change the mode.