### PR TITLE
Allow defining the shop root

### DIFF
--- a/config/_config.php
+++ b/config/_config.php
@@ -24,5 +24,15 @@ $configuration = [
      * @param string selfUpdate stable, latest
      */
     'installMode' => 'copy',
-    'selfUpdate' => 'stable'
+    'selfUpdate' => 'stable',
+
+    /**
+     * Settings revolving around your modified-shop
+     *
+     * Overwrite the default shop path. If your MMLC installation is not inside
+     * of your modified-shop root and exists as a symbolic link, you may need to
+     * define your shop root here.
+     *
+     * 'shopRoot' => '/path/to/modified-shop',
+     */
 ];

--- a/src/Classes/App.php
+++ b/src/Classes/App.php
@@ -40,7 +40,11 @@ class App
 
     public static function getShopRoot(): string
     {
-        return realPath(__DIR__ . '/../../../');
+        $shopRoot = empty(Config::getOption('shopRoot'))
+                  ? realpath(__DIR__ . '/../../../')
+                  : rtrim(Config::getOption('shopRoot'), '/\\');
+
+        return $shopRoot;
     }
 
     public static function getSrcRoot(): string


### PR DESCRIPTION
Due to my file structure `App::getShopRoot` returns the wrong directory.

- modified-shop directory: `[...]/grandeljay/modified-shop` (contains a symbolic link to **MMLC directory**)
- MMLC directory:  `[...]/RobinTheHood/ModifiedModuleLoaderClient` 

In this setup `App:getShopRoot` returns `realpath(__DIR__ . '/../../../')` which in my case is `[...]/RobinTheHood` instead of `[...]/grandeljay/modified-shop`.

I think it would be best to allow an override to this behaviour.
