### PR TITLE
Use latest archive tag/version

### DIFF
--- a/src/Classes/ModuleCreator.php
+++ b/src/Classes/ModuleCreator.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace RobinTheHood\ModifiedModuleLoaderClient;
 
 use RobinTheHood\ModifiedModuleLoaderClient\App;
+use RobinTheHood\ModifiedModuleLoaderClient\Loader\RemoteModuleLoader;
 
 class ModuleCreator
 {
@@ -78,41 +79,17 @@ class ModuleCreator
 
     private function getLatestVersion(string $archiveName): string
     {
-        $version = '0.1.0';
+        $remoteModuleLoader = RemoteModuleLoader::create();
+        $module = $remoteModuleLoader->loadLatestVersionByArchiveName($archiveName);
 
         /**
-         * Create GitHub API reqest.
-         *
-         * GitHub requries a `User-Agent` header or it will respond with HTTP
-         * 403.
+         * Usually the module does not exist yet, so `$module` is `null`.
          */
-        $requestOptions = [
-            'http' => [
-                'header' => [
-                    'User-Agent: PHP',
-                ],
-            ],
-        ];
-        $requestContext  = stream_context_create($requestOptions);
-        $requestResponse = file_get_contents(
-            sprintf(
-                'https://api.github.com/repos/%s/tags',
-                $archiveName
-            ),
-            $use_include_path = false,
-            $requestContext
-        );
-
-        if (false !== $requestResponse) {
-            $archiveTags       = json_decode($requestResponse, $associative = true);
-            $archiveTagsLatest = reset($archiveTags);
-
-            if (isset($archiveTagsLatest['name'])) {
-                $version = $archiveTagsLatest['name'];
-            }
+        if (null === $module) {
+            return '0.1.0';
         }
 
-        return $version;
+        return $module->getVersion();
     }
 
     public function createModuleInfoJsonFile($vendorName, $moduleName)


### PR DESCRIPTION
When creating a new module using the script, automatically fetch the newest tag/version from GitHub and use it when possible.

I just found this script and think it's amazing! If you accept this PR I will make more with further improvements later.