### PR TITLE
Add `.gitattributes`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Force LF on all text files
+* text=auto eol=lf


### PR DESCRIPTION
I'm on Windows so files are automatically converted to `CRLF` end of line characters. This PR forces `LF` on all text files.