### PR TITLE
feat: add getOption() and improve hasOption() of Cli class

### DIFF
--- a/src/Classes/Cli/Cli.php
+++ b/src/Classes/Cli/Cli.php
@@ -88,6 +88,15 @@ class Cli
         return false;
     }
 
+    /**
+     * Returns an option from the command line.
+     *
+     * @param string $option
+     *
+     * @return mixed        (PHP 7.4)
+     * @return string|bool  (PHP 8.0)
+     * @return string|false (PHP 8.1)
+     */
     public function getOption(string $option): mixed
     {
         global $argv;

--- a/src/Classes/Cli/Cli.php
+++ b/src/Classes/Cli/Cli.php
@@ -87,4 +87,21 @@ class Cli
 
         return false;
     }
+
+    public function getOption($option)
+    {
+        global $argv;
+
+        foreach ($argv as $index => $value) {
+            $optionParts = explode('=', $value);
+            $optionName = $optionParts[0] ?? $value;
+            $optionValue = $optionParts[1] ?? '';
+
+            if ($option === $optionName) {
+                return $optionValue;
+            }
+        }
+
+        return false;
+    }
 }

--- a/src/Classes/Cli/Cli.php
+++ b/src/Classes/Cli/Cli.php
@@ -71,7 +71,7 @@ class Cli
         return $filteredArguments[$argumentIndex] ?? '';
     }
 
-    public function hasOption($option)
+    public function hasOption(string $option): bool
     {
         global $argv;
 
@@ -88,7 +88,7 @@ class Cli
         return false;
     }
 
-    public function getOption($option)
+    public function getOption(string $option): mixed
     {
         global $argv;
 

--- a/src/Classes/Cli/Cli.php
+++ b/src/Classes/Cli/Cli.php
@@ -74,6 +74,17 @@ class Cli
     public function hasOption($option)
     {
         global $argv;
-        return in_array($option, $argv);
+
+        foreach ($argv as $index => $value) {
+            $optionParts = explode('=', $value);
+            $optionName = $optionParts[0] ?? $value;
+            $optionValue = $optionParts[1] ?? '';
+
+            if ($option === $optionName) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/Classes/Cli/Cli.php
+++ b/src/Classes/Cli/Cli.php
@@ -75,6 +75,10 @@ class Cli
     {
         global $argv;
 
+        if (in_array($option, $argv)) {
+            return true;
+        };
+
         foreach ($argv as $value) {
             $optionParts = explode('=', $value);
             $optionName = $optionParts[0] ?? $value;

--- a/src/Classes/Cli/Cli.php
+++ b/src/Classes/Cli/Cli.php
@@ -75,10 +75,9 @@ class Cli
     {
         global $argv;
 
-        foreach ($argv as $index => $value) {
+        foreach ($argv as $value) {
             $optionParts = explode('=', $value);
             $optionName = $optionParts[0] ?? $value;
-            $optionValue = $optionParts[1] ?? '';
 
             if ($option === $optionName) {
                 return true;

--- a/src/Classes/Cli/Cli.php
+++ b/src/Classes/Cli/Cli.php
@@ -96,11 +96,9 @@ class Cli
      *
      * @param string $option
      *
-     * @return mixed        (PHP 7.4)
-     * @return string|bool  (PHP 8.0)
-     * @return string|false (PHP 8.1)
+     * @return string
      */
-    public function getOption(string $option): mixed
+    public function getOption(string $option): string
     {
         global $argv;
 
@@ -114,6 +112,6 @@ class Cli
             }
         }
 
-        return false;
+        return '';
     }
 }


### PR DESCRIPTION
When using the `create` command options such as `--prefix=VENDOR_PREFIX` cannot be checked. With this PR you can use:
```php
$cli->hasOption('--prefix')
```
and 
```php
$cli->getOption('--prefix')
```
which would return `VENDOR_PREFIX`.