### PR TITLE
Add error message for missing `openssl` extension

### DIFF
--- a/src/Classes/Api/V1/HttpRequest.php
+++ b/src/Classes/Api/V1/HttpRequest.php
@@ -165,6 +165,11 @@ class HttpRequest
         if ($result === false) {
             $error = error_get_last();
             $errorMessage = $error['message'] ?? '';
+
+            if (empty($errorMessage) && !\extension_loaded('openssl')) {
+                $errorMessage = 'The OpenSSL PHP extension is required for https requests.';
+            }
+
             StaticLogger::log(LogLevel::ERROR, "Error-Response from $url\n$errorMessage");
             throw new RuntimeException('Error sending the POST request: ' . $errorMessage);
         }


### PR DESCRIPTION
When the OpenSSL (`openssl`) PHP extension is deactivated, the MMLC does not load causing a fatal error without any information on what the issue is. The error message is completely empty making the log entry useless.
<img width="912" height="489" alt="image" src="https://github.com/user-attachments/assets/11cb838f-b4e0-4335-85c0-2b70ee9b2184" />

Excerpt from `/logs/error/*.log`:

```log
[2025-08-27 10:55:59] ERROR: Error-Response from https://app.module-loader.de/api.php
[2025-08-27 10:56:00] ERROR: Error sending the POST request: 
```

This PR adds an indicator on what could have gone wrong:
```
[2025-08-27 10:55:59] ERROR: Error-Response from https://app.module-loader.de/api.php
The OpenSSL PHP extension is required for https requests.
[2025-08-27 10:56:00] ERROR: Error sending the POST request: The OpenSSL PHP extension is required for https requests.
```