### PR TITLE
fix: #158 renamed admin directory not found during install

### DIFF
--- a/mmlc_installer.php
+++ b/mmlc_installer.php
@@ -242,15 +242,13 @@ class Installer
             $fileName = basename($filePath);
             $fileNameLower = strtolower($fileName);
 
-            if (strpos($fileNameLower, 'admin') !== 0) {
-                continue;
+            if (strpos($fileNameLower, 'admin') !== false && is_dir($fileName)) {
+                $adminDirs[] = $fileName;
             }
 
-            if (!file_exists($filePath . '/check_update.php')) {
-                continue;
+            if (file_exists($filePath . '/check_update.php')) {
+                $adminDirs[] = $fileName;
             }
-
-            $adminDirs[] = $fileName;
         }
 
         return $adminDirs;


### PR DESCRIPTION
This PR fixes the MMLC installer not finding admin directories without the "admin" text.